### PR TITLE
Add a method of providing additional metadata and contact name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This repo contains a Nagios plugin to send Nagios notifications to incident.io.
     command_line    /usr/local/nagios/libexec/notify_incident_io \
                     --api_url="<your_api_url>" \
                     --token="<your_api_token>" \
+                    --metadata="{}" \
                     --host_name="$HOSTNAME$" \
                     --host_address="$HOSTADDRESS$" \
                     --host_alias="$HOSTALIAS$" \
@@ -39,6 +40,8 @@ This repo contains a Nagios plugin to send Nagios notifications to incident.io.
                     --service_duration="$SERVICEDURATION$" \
                     --host_duration="$HOSTDURATION$" \
                     --last_service_check="$LASTSERVICECHECK$" \
+                    --contact_name="$CONTACTNAME$" \
+                    --content_alias="$CONTENTALIAS$" \
                     --last_host_check="$LASTHOSTCHECK$" \
                     --service_notification_number="$SERVICENOTIFICATIONNUMBER$" \
                     --host_notification_number="$HOSTNOTIFICATIONNUMBER$"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This repo contains a Nagios plugin to send Nagios notifications to incident.io.
                     --last_service_check="$LASTSERVICECHECK$" \
                     --contact_name="$CONTACTNAME$" \
                     --content_alias="$CONTENTALIAS$" \
+                    --contact_group_alias="$CONTACTGROUPALIAS$" \
                     --last_host_check="$LASTHOSTCHECK$" \
                     --service_notification_number="$SERVICENOTIFICATIONNUMBER$" \
                     --host_notification_number="$HOSTNOTIFICATIONNUMBER$"

--- a/main.go
+++ b/main.go
@@ -26,7 +26,6 @@ func sendIncidentNotification(apiURL, token string, incidentData AlertSourcePayl
 		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 
-	// Log the payload, for debugging
 	fmt.Println("Sending incident.io notification with payload:")
 	fmt.Println(string(jsonData))
 

--- a/main.go
+++ b/main.go
@@ -86,6 +86,7 @@ func main() {
 	hostNotificationNumber := flag.String("host_notification_number", "", "The notification number for the host")
 	contactName := flag.String("contact_name", "", "The name of the contact")
 	contactAlias := flag.String("contact_alias", "", "The alias of the contact")
+	contactGroupAlias := flag.String("contact_group_alias", "", "The alias of the contact group")
 	otherMetadata := flag.String("metadata", "", "Additional metadata in JSON format")
 
 	// Parse the command-line arguments
@@ -206,6 +207,9 @@ func main() {
 	}
 	if contactAlias != nil && *contactAlias != "" {
 		metadata["contact_alias"] = *contactAlias
+	}
+	if contactGroupAlias != nil && *contactGroupAlias != "" {
+		metadata["contact_group_alias"] = *contactGroupAlias
 	}
 
 	// Parse additional metadata from JSON string


### PR DESCRIPTION
- Contact name group could potentially help delineate the team that owns something, so we should pull it through
- Failing that, people now have the option of providing `metadata` which could contain something like `{"team": "onboarding"}`