### PR TITLE
Staticly Link Binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ build:
 # Cross-compile binaries for all target platforms
 release: clean
 	@for platform in $(PLATFORMS); do \
-		GOOS=$${platform%/*} GOARCH=$${platform#*/} go build $(BUILD_FLAGS) -o $(BINARY)-$${platform%/*}-$${platform#*/} main.go || exit 1; \
+		CGO_ENABLED=0 GOOS=$${platform%/*} GOARCH=$${platform#*/} go build $(BUILD_FLAGS) -o $(BINARY)-$${platform%/*}-$${platform#*/} main.go || exit 1; \
 	done
 
 # Clean up build artifacts


### PR DESCRIPTION
Description: This update modifies the release target in the Makefile to add CGO_ENABLED=0 to the build command. Disabling cgo ensures that the generated binaries are statically linked, eliminating dependencies on platform-specific C libraries (such as glibc). This increases the portability of the binaries, allowing them to run on a wider range of Linux distributions, including those without glibc or using alternatives like musl.

Why: Without CGO_ENABLED=0, binaries may rely on glibc, which can cause runtime issues on systems that either lack glibc or use incompatible versions. By statically linking the binary, we ensure greater compatibility across different environments.

Testing:
Tested on multiple versions of Linux AMIs, no longer throwing error that is present in current release version

Existing Error:
```
./notify_incident_io-linux-amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./notify_incident_io-linux-amd64)
./notify_incident_io-linux-amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ./notify_incident_io-linux-amd64)
```