### PR TITLE
Allow status determination from host-only or service-only states

### DIFF
--- a/main.go
+++ b/main.go
@@ -140,7 +140,16 @@ func main() {
 		// Neither host nor service state is provided, default to firing
 		status = "firing"
 	}
-	fmt.Print("States are: ", *hostState, *serviceState, "\n")
+	// Safely print states, handling nil pointers
+	hostStateValue := "<nil>"
+	if hostState != nil {
+		hostStateValue = *hostState
+	}
+	serviceStateValue := "<nil>"
+	if serviceState != nil {
+		serviceStateValue = *serviceState
+	}
+	fmt.Print("States are: ", hostStateValue, " ", serviceStateValue, "\n")
 
 	deduplicationKey := ""
 	if overrideDeduplicationKey != nil && *overrideDeduplicationKey != "" {

--- a/main.go
+++ b/main.go
@@ -112,11 +112,32 @@ func main() {
 		title = "Nagios Notification"
 	}
 
-	// Only record positive state if both host and service are OK
+	// Determine status based on available host and service states
 	var status string
-	if hostState != nil && serviceState != nil && *hostState == "UP" && *serviceState == "OK" {
-		status = "resolved"
+	
+	// If both host and service are provided, both must be OK/UP for resolved status
+	if hostState != nil && *hostState != "" && serviceState != nil && *serviceState != "" {
+		if *hostState == "UP" && *serviceState == "OK" {
+			status = "resolved"
+		} else {
+			status = "firing"
+		}
+	} else if hostState != nil && *hostState != "" {
+		// Only host state is provided
+		if *hostState == "UP" {
+			status = "resolved"
+		} else {
+			status = "firing"
+		}
+	} else if serviceState != nil && *serviceState != "" {
+		// Only service state is provided
+		if *serviceState == "OK" {
+			status = "resolved"
+		} else {
+			status = "firing"
+		}
 	} else {
+		// Neither host nor service state is provided, default to firing
 		status = "firing"
 	}
 	fmt.Print("States are: ", *hostState, *serviceState, "\n")


### PR DESCRIPTION
We haven't been handling cases the payload _only_ contains a service, or _only_ contains a host. Now, we are a little more flexible and allow for both. 

Internal Slack thread with additional context [here](https://incident-io.slack.com/archives/C084ZFWM85B/p1749322598708729?thread_ts=1749322598.708729&cid=C084ZFWM85B)